### PR TITLE
Fix leak in Mac homedir().

### DIFF
--- a/src/abstract_platform.cpp
+++ b/src/abstract_platform.cpp
@@ -102,7 +102,7 @@ int Platform::applyHooks(std::string moduleName, std::list<CodeHook> &hooks) {
 std::string Platform::homedir() {
     char *home = getenv("HOME");
     if (home) {
-        return strdup(home);
+        return home;
     } else {
         struct passwd pw, *pwp;
         char buf[1024];


### PR DESCRIPTION
Note: I do not have a Mac so this has not been tested, but it looks like an obvious leak to me because the implicit cast to std::string will make a copy of the strdup'ed char * (not take ownership). The Windows implementation below avoids this bug.